### PR TITLE
fix error and mem leak found by cppcheck

### DIFF
--- a/src/loadlib_rel.c
+++ b/src/loadlib_rel.c
@@ -141,7 +141,7 @@ static void setprogdir(lua_State *L) {
   char progdir[_PATH_MAX + 1];
   char *lb;
   int nsize = sizeof(progdir)/sizeof(char);
-  int n;
+  int n = 0;
 #if defined(__CYGWIN__)
   char win_buff[_PATH_MAX + 1];
   GetModuleFileNameA(NULL, win_buff, nsize);
@@ -186,6 +186,7 @@ static void setprogdir(lua_State *L) {
   sprintf(cmd, "lsof -p %d | awk '{if ($5==\"REG\") { print $9 ; exit}}' 2> /dev/null", pid);
   fd = popen(cmd, "r");
   n = fread(progdir, 1, nsize, fd);
+  pclose(fd);
 
   // remove newline
   if (n > 1) progdir[--n] = '\0';


### PR DESCRIPTION
I ran cppcheck on luaDist/lua and it found these errors:
loadlib_rel.c   202 resourceLeak    error   Resource leak: fd
loadlib_rel.c   193 uninitvar   error   Uninitialized variable: n

First one was in the #else and second one in the #elif defined(**APPLE**)
