### PR TITLE
Allow for optional static compilation by overriding BUILD_SHARED_LIBS to OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ endif ( )
 
 ## BUILD
 # Create lua library
-add_library ( liblua SHARED ${SRC_CORE} ${SRC_LIB} ${LUA_DLL_RC} ${LUA_DEF} )
+add_library ( liblua ${SRC_CORE} ${SRC_LIB} ${LUA_DLL_RC} ${LUA_DEF} )
 target_link_libraries ( liblua ${LIBS} )
 set_target_properties ( liblua PROPERTIES OUTPUT_NAME lua CLEAN_DIRECT_OUTPUT 1 )
 if ( LUA_BUILD_AS_DLL )


### PR DESCRIPTION
The default remains building liblua as a shared library because [BUILD_SHARED_LIBS](http://www.cmake.org/cmake/help/cmake2.6docs.html#variable:BUILD_SHARED_LIBS) is set to ON in `dist.cmake`. However, this patch makes it possible to build statically by changing this variable.
