### PR TITLE
Fixed a signed integer overflow check.

### DIFF
--- a/src/ltablib.c
+++ b/src/ltablib.c
@@ -5,6 +5,7 @@
 */
 
 
+#include <limits.h>
 #include <stddef.h>
 
 #define ltablib_c
@@ -139,8 +140,17 @@ static int unpack (lua_State *L) {
   i = luaL_optint(L, 2, 1);
   e = luaL_opt(L, luaL_checkint, 3, luaL_len(L, 1));
   if (i > e) return 0;  /* empty range */
-  n = e - i + 1;  /* number of elements */
-  if (n <= 0 || !lua_checkstack(L, n))  /* n <= 0 means arith. overflow */
+  if (i == INT_MIN) {
+    if (e >= -1)
+      return luaL_error(L, "too many result to unpack");
+    n = (2 + e) + INT_MAX;  /* handle i = INT_MIN safely */
+  } else {
+    /* checking for overflow of n in safe manner */
+    if (e >= -1 && -i > INT_MAX - (e + 1))
+      return luaL_error(L, "too many results to unpack");
+    n = e - i + 1;  /* number of elements */
+  }
+  if (!lua_checkstack(L, n))
     return luaL_error(L, "too many results to unpack");
   lua_rawgeti(L, 1, i);  /* push arg[i] (avoiding overflow problems) */
   while (i++ < e)  /* push arg[i + 1...e] */


### PR DESCRIPTION
Signed integer overflow is undefined behavior in C. In this commit we patch a
signed integer check in ltablib.c in the function unpack.

This patch may need to be modified under the constraints of two operations

```
ltablib.c:140
i = luaL_optint(L, 2, 1)

ltablib.c:141
e = luaL_opt(L, luaL_checkint, 3, luaL_len(L, 1)
```

Here, we assume i and e can be any value in its given type, int. If this is
true, we must check for some special cases. If i is INT_MIN, we can't just take
the negative value of it, as -INT_MIN = INT_MAX+1 (theoretically) which is
undefined behavior.

The original check against the value of

```
n = e - i + 1
```

was

```
n <= 0
```

to check for signed integer overflow. Signed integer overflow is undefined
behavior.
