### PR TITLE
Add "LUA_LINK_MSVCRT_STATIC" option for Visual Studio target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ if ( WIN32 AND NOT CYGWIN )
   option ( LUA_WIN "Windows specific build." ON )
   option ( LUA_BUILD_WLUA "Build wLua interpretter without console output." ON )
   option ( LUA_BUILD_AS_DLL "Build Lua library as Dll." ${BUILD_SHARED_LIBS} )
+  option ( LUA_LINK_MSVCRT_STATIC "Build Lua library with static linkage to MSVCRT" )
   
   # Paths (Double escapes ne  option needed)
   set ( LUA_DIRSEP "\\\\" )

--- a/cmake/dist.cmake
+++ b/cmake/dist.cmake
@@ -76,9 +76,14 @@ set ( CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS true )
 set ( CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH} )
 option ( BUILD_SHARED_LIBS "Build shared libraries" ON )
 
-# In MSVC, prevent warnings that can occur when using standard libraries.
 if ( MSVC )
+  # In MSVC, prevent warnings that can occur when using standard libraries.
   add_definitions ( -D_CRT_SECURE_NO_WARNINGS )
+
+  if ( LUA_LINK_MSVCRT_STATIC )
+    set ( CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /MT" )
+    set ( CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /MTd" )
+  endif ()
 endif ()
 
 # RPath and relative linking


### PR DESCRIPTION
The new option "LUA_LINK_MSVCRT_STATIC" enables adding compile option "/MT" (or "/MTd" for Debug configuration) for Visual Studio generator.
Without this option, all binaries will have dynamic linkage to "MSVCR120.dll" or something.